### PR TITLE
Add wireport - performant tunelling (tcp,udp,auto-tls/ssl); stands out with docker hostname resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,8 @@ NetMaker Architecture. Credit: [Netmaker](https://netmaker.readthedocs.io/en/v0.
 
 [Headscale](https://github.com/juanfont/headscale) is an open source, self-hosted implementation of the Tailscale coordination server.
 
+[wireport](https://github.com/MultionLabs/wireport) - WireGuard-based ingress-proxy. More than just performant tunneling (HTTP(-s)/2, WebSockets, gRPC, TCP, UDP, auto-TLS/SSL): securely resolves remote Docker container names as local hostnames, accelerating production debugging and local development workflows. Easy self-hosting (no tinkering with docker-compose and configs).
+
 [Terraform-provider-Tailscale](https://github.com/tailscale/terraform-provider-tailscale) is a project for for the [Tailscale Terraform provider](https://registry.terraform.io/providers/tailscale/tailscale). This Terraform provider that lets you interact with the [Tailscale](https://tailscale.com/) API.
 
 [Tailscale Chocolatey Package](https://github.com/tailscale/tailscale-chocolatey) is a [Chocolatey](https://chocolatey.org/) package of the [Tailscale](https://tailscale.com/) client, the private networking solution.


### PR DESCRIPTION
WireGuard-based ingress proxy. In addition to the standard ingress proxy functionality (performant, low-memory-footprint tunneling of HTTP(-s)/2, WebSockets, gRPC, TCP, UDP traffic and automatic provisioning of free TLS/SSL certificates), [wireport](https://github.com/MultionLabs/wireport) streamlines production debugging and local development workflows by securely resolving remote Docker container names as local hostnames.

Self-hosted. Open source (MIT). [Easy setup](https://youtu.be/9wvxT-QOZ2Q) (no tinkering with docker-compose files/configs).

<img width="1667" height="1056" alt="image" src="https://github.com/user-attachments/assets/98640042-1cbf-4cea-8f0a-ae1298b7ef9b" />
